### PR TITLE
Add implementation and tests for datetime.deltatime

### DIFF
--- a/python/common/org/python/stdlib/datetime/timedelta.java
+++ b/python/common/org/python/stdlib/datetime/timedelta.java
@@ -89,7 +89,7 @@ public class timedelta extends org.python.types.Object {
             seconds += MAX_SECONDS;
             microseconds += MAX_MICROS + 1;
 
-            // IF we overflow MAX_SECONDS again
+            // If we overflow MAX_SECONDS again
             days += (long) (seconds / (24 * 60 * 60));
             seconds -= (long) (seconds / (24 * 60 * 60)) * 24 * 60 * 60;
         }

--- a/python/common/org/python/stdlib/datetime/timedelta.java
+++ b/python/common/org/python/stdlib/datetime/timedelta.java
@@ -47,7 +47,7 @@ public class timedelta extends org.python.types.Object {
         normalize(days, seconds, microseconds);
     }
 
-    @org.python.Method(__doc__ = "Creates empty timedelta", default_args = { "iterable" }, kwargs = "kwargs")
+    @org.python.Method(__doc__ = "Creates empty timedelta", kwargs = "kwargs")
     public timedelta(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
         double days = 0;
         double seconds = 0;

--- a/python/common/org/python/stdlib/datetime/timedelta.java
+++ b/python/common/org/python/stdlib/datetime/timedelta.java
@@ -3,7 +3,6 @@ package org.python.stdlib.datetime;
 import java.math.BigDecimal;
 
 public class timedelta extends org.python.types.Object {
-
     private static final long MAX_DAYS = 999999999;
     private static final long MAX_SECONDS = 60 * 60 * 24 - 1;
     private static final long MAX_MICROS = 1000000 - 1;

--- a/python/common/org/python/stdlib/datetime/timedelta.java
+++ b/python/common/org/python/stdlib/datetime/timedelta.java
@@ -75,7 +75,6 @@ public class timedelta extends org.python.types.Object {
         microseconds += (seconds % 1) * 1e6;
         seconds -= seconds % 1;
 
-        // round the answer to whole microseconds
         microseconds = roundHalfToEven(microseconds);
 
         // convert many microseconds to seconds

--- a/python/common/org/python/stdlib/datetime/timedelta.java
+++ b/python/common/org/python/stdlib/datetime/timedelta.java
@@ -50,7 +50,7 @@ public class timedelta extends org.python.types.Object {
         normalize(days, seconds, microseconds);
     }
 
-    @org.python.Method(__doc__ = "Creates empty timedelta", kwargs = "kwargs")
+    @org.python.Method(__doc__ = "A timedelta object represents a duration, the difference between two dates or times.\n", kwargs = "kwargs")
     public timedelta(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
         double days = 0;
         double seconds = 0;
@@ -122,7 +122,7 @@ public class timedelta extends org.python.types.Object {
     @org.python.Method(__doc__ = "Return the total number of seconds contained in the duration.\n"
             + " Equivalent to td / timedelta(seconds=1). For interval units \n"
             + "other than seconds, use the division form directly \n"
-            + "(e.g. td / timedelta(microseconds=1)).", args = {})
+            + "(e.g. td / timedelta(microseconds=1)).\n", args = {})
     public org.python.Object total_seconds() {
         // Regular double precision isn't enough! We need the big stuff
         BigDecimal daysInSeconds = BigDecimal.valueOf(days.value).multiply(BigDecimal.valueOf(24 * 60 * 60));
@@ -148,7 +148,7 @@ public class timedelta extends org.python.types.Object {
     }
 
     @Override
-    @org.python.Method(__doc__ = "Return self*value", args = { "other" })
+    @org.python.Method(__doc__ = "Return self*value\n", args = { "other" })
     public org.python.Object __mul__(org.python.Object other) {
         if (other instanceof org.python.types.Int || other instanceof org.python.types.Float) {
             double mult = getFloatvalue(other);
@@ -158,7 +158,7 @@ public class timedelta extends org.python.types.Object {
     }
 
     @Override
-    @org.python.Method(__doc__ = "Return self+value.", args = { "other" })
+    @org.python.Method(__doc__ = "Return self+value.\n", args = { "other" })
     public org.python.Object __add__(org.python.Object other) {
         if (other instanceof org.python.stdlib.datetime.timedelta) {
             timedelta otherTd = (timedelta) other;

--- a/python/common/org/python/stdlib/datetime/timedelta.java
+++ b/python/common/org/python/stdlib/datetime/timedelta.java
@@ -124,7 +124,7 @@ public class timedelta extends org.python.types.Object {
             + "other than seconds, use the division form directly \n"
             + "(e.g. td / timedelta(microseconds=1)).\n", args = {})
     public org.python.Object total_seconds() {
-        // Regular double precision isn't enough! We need the big stuff
+        // Python handles doubles larger than the standard double in Java, thus we have to use BigDecimal
         BigDecimal daysInSeconds = BigDecimal.valueOf(days.value).multiply(BigDecimal.valueOf(24 * 60 * 60));
         BigDecimal bigSeconds = BigDecimal.valueOf(seconds.value);
         BigDecimal microsecondsInSeconds = BigDecimal.valueOf(microseconds.value).divide(BigDecimal.valueOf(1e6));

--- a/python/common/org/python/stdlib/datetime/timedelta.java
+++ b/python/common/org/python/stdlib/datetime/timedelta.java
@@ -1,0 +1,183 @@
+package org.python.stdlib.datetime;
+
+import java.math.BigDecimal;
+
+public class timedelta extends org.python.types.Object {
+
+    private static final long MAX_DAYS = 999999999;
+    private static final long MAX_SECONDS = 60 * 60 * 24 - 1;
+    private static final long MAX_MICROS = 1000000 - 1;
+
+    @org.python.Attribute
+    public final static org.python.Object min = new timedelta(-MAX_DAYS, 0, 0);
+    @org.python.Attribute
+    public final static org.python.Object max = new timedelta(MAX_DAYS, MAX_SECONDS, MAX_MICROS);
+    @org.python.Attribute
+    public final static org.python.Object resolution = new timedelta(0, 0, 1);
+
+    @org.python.Attribute
+    public org.python.types.Int days;
+    @org.python.Attribute
+    public org.python.types.Int seconds;
+    @org.python.Attribute
+    public org.python.types.Int microseconds;
+
+    private double getArg(int position, String keyword, org.python.Object[] args,
+            java.util.Map<java.lang.String, org.python.Object> kwargs) {
+        boolean hasPositional = args.length > position && args[position] != null;
+        boolean hasKeyword = kwargs.containsKey(keyword);
+
+        if (hasPositional && hasKeyword) {
+            throw new org.python.exceptions.TypeError(
+                    String.format("Argument given by name ('%s') and position (%d)", keyword, position + 1));
+        } else if (hasPositional) {
+            return getFloatvalue(args[position]);
+        } else if (hasKeyword) {
+            return getFloatvalue(kwargs.get(keyword));
+        } else {
+            return 0;
+        }
+    }
+
+    private timedelta(long days, long seconds, long microseconds) {
+        this((double) days, (double) seconds, (double) microseconds);
+    }
+
+    private timedelta(double days, double seconds, double microseconds) {
+        normalize(days, seconds, microseconds);
+    }
+
+    @org.python.Method(__doc__ = "Creates empty timedelta", default_args = { "iterable" }, kwargs = "kwargs")
+    public timedelta(org.python.Object[] args, java.util.Map<java.lang.String, org.python.Object> kwargs) {
+        double days = 0;
+        double seconds = 0;
+        double microseconds = 0;
+
+        days += getArg(0, "days", args, kwargs);
+        seconds += getArg(1, "seconds", args, kwargs);
+        microseconds += getArg(2, "microseconds", args, kwargs);
+        microseconds += getArg(3, "milliseconds", args, kwargs) * 1000;
+        seconds += getArg(4, "minutes", args, kwargs) * 60;
+        seconds += getArg(5, "hours", args, kwargs) * 60 * 60;
+        days += getArg(6, "weeks", args, kwargs) * 7;
+
+        normalize(days, seconds, microseconds);
+    }
+
+    private void normalize(double days, double seconds, double microseconds) {
+        // convert decimals to smaller units e.g. 1.5 days => 1 days and 43200 seconds
+        seconds += (days % 1) * 60 * 60 * 24;
+        days -= days % 1;
+
+        microseconds += (seconds % 1) * 1e6;
+        seconds -= seconds % 1;
+
+        // round the answer to whole microseconds
+        microseconds = roundHalfToEven(microseconds);
+
+        // convert many microseconds to seconds
+        seconds += (long) (microseconds / 1e6);
+        microseconds -= ((long) (microseconds / 1e6)) * 1e6;
+        // convert many seconds to days
+        days += (long) (seconds / (24 * 60 * 60));
+        seconds -= (long) (seconds / (24 * 60 * 60)) * 24 * 60 * 60;
+
+        if (microseconds < 0) {
+            days -= 1;
+            seconds += MAX_SECONDS;
+            microseconds += MAX_MICROS + 1;
+
+            // IF we overflow MAX_SECONDS again
+            days += (long) (seconds / (24 * 60 * 60));
+            seconds -= (long) (seconds / (24 * 60 * 60)) * 24 * 60 * 60;
+        }
+        if (seconds < 0) {
+            days -= 1;
+            seconds += MAX_SECONDS + 1;
+        }
+
+        if (Math.abs(days) > MAX_DAYS) {
+            throw new org.python.exceptions.OverflowError(
+                    String.format("days=%d; must have magnitude <= %d", (long) days, MAX_DAYS));
+        }
+
+        this.days = org.python.types.Int.getInt((long) days);
+        this.seconds = org.python.types.Int.getInt((long) seconds);
+        this.microseconds = org.python.types.Int.getInt((long) microseconds);
+    }
+
+    private static long roundHalfToEven(double d) {
+        if (d % 0.5 == 0 && d % 1 != 0) {
+            if (Math.floor(d) % 2 == 0) {
+                return (long) Math.floor(d);
+            } else {
+                return (long) Math.ceil(d);
+            }
+        }
+        return Math.round(d);
+    }
+
+    @org.python.Method(__doc__ = "Return the total number of seconds contained in the duration.\n"
+            + " Equivalent to td / timedelta(seconds=1). For interval units \n"
+            + "other than seconds, use the division form directly \n"
+            + "(e.g. td / timedelta(microseconds=1)).", args = {})
+    public org.python.Object total_seconds() {
+        // Regular double precision isn't enough! We need the big stuff
+        BigDecimal daysInSeconds = BigDecimal.valueOf(days.value).multiply(BigDecimal.valueOf(24 * 60 * 60));
+        BigDecimal bigSeconds = BigDecimal.valueOf(seconds.value);
+        BigDecimal microsecondsInSeconds = BigDecimal.valueOf(microseconds.value).divide(BigDecimal.valueOf(1e6));
+        BigDecimal total = daysInSeconds.add(bigSeconds).add(microsecondsInSeconds);
+        return new org.python.types.Float(total.doubleValue());
+    }
+
+    private long getIntValue(org.python.Object obj) {
+        return ((org.python.types.Int) obj.__int__()).value;
+    }
+
+    private double getFloatvalue(org.python.Object obj) {
+        if (obj.typeName().equals("int")) {
+            // if obj is really an integer -> cast to double in order to bypass __float__()
+            // function wich will cast
+            // the value into a 32-bit float.
+            return (double) getIntValue(obj);
+        } else {
+            return ((org.python.types.Float) obj.__float__()).value;
+        }
+    }
+
+    @Override
+    @org.python.Method(
+            __doc__ = "Return self*value",
+            args = {"other"}
+    )
+    public org.python.Object __mul__(org.python.Object other) {
+        if (other instanceof org.python.types.Int || other instanceof org.python.types.Float) {
+            double mult = getFloatvalue(other);
+            return new timedelta(mult * this.days.value,
+                    this.seconds.value * mult, 
+                    this.microseconds.value * mult);
+        }
+        return super.__mul__(other);
+    }
+
+    @Override
+    @org.python.Method(
+            __doc__ = "Return self+value.",
+            args = {"other"}
+    )
+    public org.python.Object __add__(org.python.Object other) {
+        if (other instanceof org.python.stdlib.datetime.timedelta) {
+            timedelta otherTd = (timedelta) other;
+            return new timedelta(this.days.value + otherTd.days.value, 
+                                this.seconds.value + otherTd.seconds.value,
+                                this.microseconds.value + otherTd.microseconds.value);
+        } else {
+            return super.__add__(other);
+        }
+    }
+
+    @Override
+    public java.lang.String typeName() {
+        return "datetime.timedelta";
+    }
+}

--- a/python/common/org/python/stdlib/datetime/timedelta.java
+++ b/python/common/org/python/stdlib/datetime/timedelta.java
@@ -7,13 +7,17 @@ public class timedelta extends org.python.types.Object {
     private static final long MAX_DAYS = 999999999;
     private static final long MAX_SECONDS = 60 * 60 * 24 - 1;
     private static final long MAX_MICROS = 1000000 - 1;
+    private static final long RESOLUTION_DAYS = 0;
+    private static final long RESOLUTION_SECONDS = 0;
+    private static final long RESOLUTION_MICROS = 1;
 
     @org.python.Attribute
     public final static org.python.Object min = new timedelta(-MAX_DAYS, 0, 0);
     @org.python.Attribute
     public final static org.python.Object max = new timedelta(MAX_DAYS, MAX_SECONDS, MAX_MICROS);
     @org.python.Attribute
-    public final static org.python.Object resolution = new timedelta(0, 0, 1);
+    public final static org.python.Object resolution = new timedelta(RESOLUTION_DAYS, RESOLUTION_SECONDS,
+            RESOLUTION_MICROS);
 
     @org.python.Attribute
     public org.python.types.Int days;
@@ -146,31 +150,22 @@ public class timedelta extends org.python.types.Object {
     }
 
     @Override
-    @org.python.Method(
-            __doc__ = "Return self*value",
-            args = {"other"}
-    )
+    @org.python.Method(__doc__ = "Return self*value", args = { "other" })
     public org.python.Object __mul__(org.python.Object other) {
         if (other instanceof org.python.types.Int || other instanceof org.python.types.Float) {
             double mult = getFloatvalue(other);
-            return new timedelta(mult * this.days.value,
-                    this.seconds.value * mult, 
-                    this.microseconds.value * mult);
+            return new timedelta(mult * this.days.value, this.seconds.value * mult, this.microseconds.value * mult);
         }
         return super.__mul__(other);
     }
 
     @Override
-    @org.python.Method(
-            __doc__ = "Return self+value.",
-            args = {"other"}
-    )
+    @org.python.Method(__doc__ = "Return self+value.", args = { "other" })
     public org.python.Object __add__(org.python.Object other) {
         if (other instanceof org.python.stdlib.datetime.timedelta) {
             timedelta otherTd = (timedelta) other;
-            return new timedelta(this.days.value + otherTd.days.value, 
-                                this.seconds.value + otherTd.seconds.value,
-                                this.microseconds.value + otherTd.microseconds.value);
+            return new timedelta(this.days.value + otherTd.days.value, this.seconds.value + otherTd.seconds.value,
+                    this.microseconds.value + otherTd.microseconds.value);
         } else {
             return super.__add__(other);
         }

--- a/python/common/python/datetime.java
+++ b/python/common/python/datetime.java
@@ -1,0 +1,31 @@
+package python;
+
+@org.python.Module(
+    __doc__ = "This module provides various functions to datetime." 
+)
+public class datetime extends org.python.types.Module {
+    public datetime() {
+        super();
+    }
+
+    static {
+        timedelta = org.python.types.Type.pythonType(org.python.stdlib.datetime.timedelta.class);
+    }
+
+
+    @org.python.Attribute()
+    public static org.python.Object timedelta;
+
+    @org.python.Attribute
+    public static org.python.Object __file__ = new org.python.types.Str("python/common/python/datetime.java");
+    @org.python.Attribute
+    public static org.python.Object __loader__ = org.python.types.NoneType.NONE;  // TODO
+    @org.python.Attribute
+    public static org.python.Object __name__ = new org.python.types.Str("datetime");
+    @org.python.Attribute
+    public static org.python.Object __package__ = new org.python.types.Str("");
+    @org.python.Attribute
+    public static org.python.Object __spec__ = org.python.types.NoneType.NONE;  // TODO
+
+
+}

--- a/python/common/python/datetime.java
+++ b/python/common/python/datetime.java
@@ -1,8 +1,6 @@
 package python;
 
-@org.python.Module(
-    __doc__ = "This module provides various functions to datetime." 
-)
+@org.python.Module(__doc__ = "This module provides various functions to datetime.")
 public class datetime extends org.python.types.Module {
     public datetime() {
         super();
@@ -12,20 +10,18 @@ public class datetime extends org.python.types.Module {
         timedelta = org.python.types.Type.pythonType(org.python.stdlib.datetime.timedelta.class);
     }
 
-
     @org.python.Attribute()
     public static org.python.Object timedelta;
 
     @org.python.Attribute
     public static org.python.Object __file__ = new org.python.types.Str("python/common/python/datetime.java");
     @org.python.Attribute
-    public static org.python.Object __loader__ = org.python.types.NoneType.NONE;  // TODO
+    public static org.python.Object __loader__ = org.python.types.NoneType.NONE; // TODO
     @org.python.Attribute
     public static org.python.Object __name__ = new org.python.types.Str("datetime");
     @org.python.Attribute
     public static org.python.Object __package__ = new org.python.types.Str("");
     @org.python.Attribute
-    public static org.python.Object __spec__ = org.python.types.NoneType.NONE;  // TODO
-
+    public static org.python.Object __spec__ = org.python.types.NoneType.NONE; // TODO
 
 }

--- a/tests/stdlib/test_datetime.py
+++ b/tests/stdlib/test_datetime.py
@@ -1,0 +1,248 @@
+from ..utils import TranspileTestCase
+
+
+class DatetimeModuleTests(TranspileTestCase):
+    def test_timedelta_default_constructor(self):
+        self.assertCodeExecution("""
+            import datetime
+            delta = datetime.timedelta()
+            print(delta.total_seconds())
+        """)
+
+    def test_timedelta_days_constructor(self):
+        self.assertCodeExecution("""
+            import datetime
+            print(datetime.timedelta(0).total_seconds())
+            print(datetime.timedelta(1).total_seconds())
+            print(datetime.timedelta(-1).total_seconds())
+            print(datetime.timedelta(999999999).total_seconds())
+            print(datetime.timedelta(-999999999).total_seconds())
+            print(datetime.timedelta(0.1).total_seconds())
+            print(datetime.timedelta(-0.1).total_seconds())
+            print(datetime.timedelta(1.9).total_seconds())
+            print(datetime.timedelta(-2.9).total_seconds())
+            print(datetime.timedelta(0.00001).total_seconds())
+            print(datetime.timedelta(-0.0001).total_seconds())
+            try:
+                # Test more than max days (i.e. 999999999)
+                print(datetime.timedelta(999999999+1).total_seconds())
+            except OverflowError as e:
+                print(e)
+        """)
+
+    def test_timedelta_seconds_constructor(self):
+        self.assertCodeExecution("""
+            import datetime
+            print(datetime.timedelta(0, 0).total_seconds())
+            print(datetime.timedelta(0, -1).total_seconds())
+            print(datetime.timedelta(0, 1).total_seconds())
+            print(datetime.timedelta(0, 999999999).total_seconds())
+            print(datetime.timedelta(0, -999999999).total_seconds())
+            print(datetime.timedelta(0, 0.1).total_seconds())
+            print(datetime.timedelta(0, -0.1).total_seconds())
+            print(datetime.timedelta(0, 0.9).total_seconds())
+            print(datetime.timedelta(0, -0.9).total_seconds())
+            print(datetime.timedelta(0, 1e9*60*60*24 - 1).total_seconds())
+            try:
+                # Test more than max days (i.e. 999999999)
+                print(datetime.timedelta(0, 1e9*60*60*24).total_seconds())
+            except OverflowError as e:
+                print(e)
+        """)
+
+    def test_timedelta_microseconds_constructor(self):
+        self.assertCodeExecution("""
+            import datetime
+            print(datetime.timedelta(0, 0, 0).total_seconds())
+            print(datetime.timedelta(0, 0, -1).total_seconds())
+            print(datetime.timedelta(0, 0, 1).total_seconds())
+            print(datetime.timedelta(0, 0, 999999999).total_seconds())
+            print(datetime.timedelta(0, 0, -999999999).total_seconds())
+            print(datetime.timedelta(0, 0, 0.1).total_seconds())
+            print(datetime.timedelta(0, 0, -0.1).total_seconds())
+            print(datetime.timedelta(0, 0, 0.9).total_seconds())
+            print(datetime.timedelta(0, 0, -0.9).total_seconds())
+            # Testing overflow to days
+            print(datetime.timedelta(0, 0, 1e6*24*60*60 + 1).total_seconds())
+            print(datetime.timedelta(0, 0, 1e6*24*60*60 - 1).total_seconds())
+            print(datetime.timedelta(0, 0, 1e6*24*60*60).total_seconds())
+
+            # Testing round-half-to-even
+            # Should be 2 microseconds because of round-half-to-even
+            print(datetime.timedelta(0, 0, 1.5).total_seconds())
+            # Should be 0 microseconds because of round-half-to-even
+            print(datetime.timedelta(0, 0, 0.5).total_seconds())
+        """)
+
+    def test_timedelta_milliseconds_constructor(self):
+        self.assertCodeExecution("""
+            import datetime
+            print(datetime.timedelta(0, 0, 0, 0).total_seconds())
+            print(datetime.timedelta(0, 0, 0, -1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 999999999).total_seconds())
+            print(datetime.timedelta(0, 0, 0, -999999999).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0.1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, -0.1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0.9).total_seconds())
+            print(datetime.timedelta(0, 0, 0, -0.9).total_seconds())
+            # Testing overflow to days
+            print(datetime.timedelta(0, 0, 0, 1e3*24*60*60 + 1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 1e3*24*60*60 - 1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 1e3*24*60*60).total_seconds())
+        """)
+
+    def test_timedelta_minutes_constructor(self):
+        self.assertCodeExecution("""
+            import datetime
+            print(datetime.timedelta(0, 0, 0, 0, 0).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, -1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 999999999).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, -999999999).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0.1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, -0.1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0.9).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, -0.9).total_seconds())
+        """)
+
+    def test_timedelta_hours_constructor(self):
+        self.assertCodeExecution("""
+            import datetime
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, -1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 999999999).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, -999999999).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0.1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, -0.1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0.9).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, -0.9).total_seconds())
+        """)
+
+    def test_timedelta_weeks_constructor(self):
+        self.assertCodeExecution("""
+            import datetime
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0, 0).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0, -1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0, 1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0, 999999999 / 8).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0, -999999999 / 8).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0, 0.1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0, -0.1).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0, 0.9).total_seconds())
+            print(datetime.timedelta(0, 0, 0, 0, 0, 0, -0.9).total_seconds())
+        """)
+
+    def test_timedelta_instance_attributes(self):
+        self.assertCodeExecution("""
+            import datetime
+            print(datetime.timedelta().days)
+            print(datetime.timedelta().seconds)
+            print(datetime.timedelta().microseconds)
+            print(datetime.timedelta(-1, -1, -1).days)
+            print(datetime.timedelta(-1, -1, -1).seconds)
+            print(datetime.timedelta(-1, -1, -1).microseconds)
+            print(datetime.timedelta(1.12345).days)
+            print(datetime.timedelta(1.12345).seconds)
+            print(datetime.timedelta(1.12345).microseconds)
+            print(datetime.timedelta(999.12345).days)
+            print(datetime.timedelta(999.12345).seconds)
+            print(datetime.timedelta(999.12345).microseconds)
+            print(datetime.timedelta(0, -0.1).days)
+            print(datetime.timedelta(0, -0.1).seconds)
+            print(datetime.timedelta(0, -0.1).microseconds)
+            print(datetime.timedelta(999999999).days)
+            print(datetime.timedelta(999999999).seconds)
+            print(datetime.timedelta(999999999).microseconds)
+        """)
+
+    def test_timedelta_kwargs(self):
+        self.assertCodeExecution("""
+            import datetime
+            print(datetime.timedelta(days=5).days)
+            print(datetime.timedelta(days=5).seconds)
+            print(datetime.timedelta(days=5).microseconds)
+            print(datetime.timedelta(seconds=5).days)
+            print(datetime.timedelta(seconds=5).seconds)
+            print(datetime.timedelta(seconds=5).microseconds)
+            print(datetime.timedelta(-1, seconds=5).days)
+            print(datetime.timedelta(-1, seconds=5).seconds)
+            print(datetime.timedelta(-1, seconds=5).microseconds)
+            print(datetime.timedelta(seconds=5, days=5).days)
+            print(datetime.timedelta(seconds=5, days=5).seconds)
+            print(datetime.timedelta(seconds=5, days=5).microseconds)
+            print(datetime.timedelta(1, 1, 1, weeks=1).days)
+            print(datetime.timedelta(1, 1, 1, weeks=1).seconds)
+            print(datetime.timedelta(1, 1, 1, weeks=1).microseconds)
+
+            try:
+                datetime.timedelta(1, 1, 1, days=1)
+            except TypeError as e:
+                print(e)
+        """)
+
+    def test_timedelta_class_attributes(self):
+        self.assertCodeExecution("""
+            import datetime
+            print(datetime.timedelta().min.days)
+            print(datetime.timedelta().max.days)
+            print(datetime.timedelta().resolution.days)
+            print(datetime.timedelta().min.seconds)
+            print(datetime.timedelta().max.seconds)
+            print(datetime.timedelta().resolution.seconds)
+            print(datetime.timedelta().min.microseconds)
+            print(datetime.timedelta().max.microseconds)
+            print(datetime.timedelta().resolution.microseconds)
+        """)
+
+    def test_timedelta_multiplication(self):
+        self.assertCodeExecution("""
+            import datetime
+            a = datetime.timedelta(1, 1, 1)
+            print((a*1).total_seconds())
+            print((a*0).total_seconds())
+            print((a*-1).total_seconds())
+            print((a*99999999).total_seconds())
+            print((a*-99999999).total_seconds())
+            print((a*0.9).total_seconds())
+            print((a*-0.9).total_seconds())
+            print((a*4.9).total_seconds())
+            print((a*-4.9).total_seconds())
+
+            b = datetime.timedelta(1)
+            print((b*999999999).total_seconds())
+            try:
+                print((b*(999999999+1)).total_seconds())
+            except OverflowError as e:
+                print(e)
+
+            # From documentation: "The result is rounded to the nearest multiple
+            #                       of timedelta.resolution using round-half-to-even"
+            c = datetime.timedelta(0, 0, 2)
+            print((c*0.75).total_seconds()) # Should be 2 microseconds because of round-half-to-even
+            print((c*0.25).total_seconds()) # Should be 0 microseconds because of round-half-to-even
+        """)
+
+    def test_timedelta_addition(self):
+        self.assertCodeExecution("""
+            import datetime
+            print((datetime.timedelta(1) + datetime.timedelta(0)).total_seconds())
+            print((datetime.timedelta(1) + datetime.timedelta(-1)).total_seconds())
+            print((datetime.timedelta(1) + datetime.timedelta(0, 0, 1)).total_seconds())
+            print((datetime.timedelta(1) + datetime.timedelta(0, 0, -1)).total_seconds())
+            print((datetime.timedelta(0, 0, 1) + datetime.timedelta(-1, 0, 0)).total_seconds())
+            print((datetime.timedelta(1, 1, 1) + datetime.timedelta(1, 2, 3)).total_seconds())
+            print((datetime.timedelta(999999999) + datetime.timedelta(0, 60*60*24-1, 999999)).total_seconds())
+
+            try:
+                print((datetime.timedelta(1) + 2).total_seconds())
+            except TypeError as e:
+                print(e)
+
+            try:
+                print((datetime.timedelta(999999999) + datetime.timedelta(1)).total_seconds())
+            except OverflowError as e:
+                print(e)
+
+        """)


### PR DESCRIPTION
Fixes #15 

Squashed following commits
```
Add passing total_seconds test and implementation

Add day constructor without positional argument

Add microsecond support for days timedelta

Refactor

Move rounding of microseconds to before conversion to seconds

Add kwargs to timedelta function signature

Add passing seconds argument test

Add check for overflow error in days

Add tests for microsecond agrument

Add tests for rest of arguments

Add tests for instance attributes

To fix the total_seconds method we needed better precision, thus we use BigDecimal

Add test and implementation of kwargs

Add failing class attributes

Fix the failing class attributes by using instance of the class

Fix style errors from flake8

Make class attribute test look better

Multiplication and Addition for TimeDelta (#33)

* Implement timedelta multiplication with float and int

* Fix timedelta not rounding Half to even

* Implement addition for timedelta

Fix flake8 style checks
```
```
Co-authored-by: Adam Inersjö <adam.inersjo.2778@student.uu.se>
Co-authored-by: Joel Westerlund <jowe3751@student.uu.se>
Co-authored-by: Michael Rehn <rehn.michael@outlook.com>
```

Run test with 
`ant test && python setup.py test -s tests.stdlib.test_datetime.DatetimeModuleTests`